### PR TITLE
Fix image pullback issue in Kafka and MongoDB due to Bitnami image migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Chart.lock
 
 # ignore MacOS DS_Store
 *.DS_Store
+
+*.log

--- a/5g-control-plane/Chart.yaml
+++ b/5g-control-plane/Chart.yaml
@@ -14,11 +14,11 @@ version: 2.2.9
 
 dependencies:
   - name: mongodb
-    version: 13.16.4
+    version: 16.5.45
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.deploy
   - name: kafka
-    version: 20.0.4
+    version: 32.4.3
     repository: https://charts.bitnami.com/bitnami
     condition: kafka.deploy
   - name: prometheus

--- a/5g-control-plane/templates/deployment-metricfunc.yaml
+++ b/5g-control-plane/templates/deployment-metricfunc.yaml
@@ -41,6 +41,7 @@ spec:
       - name: metricfunc
         image: {{ .Values.images.repository }}{{ .Values.images.tags.metricfunc }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
+        command: ['sh', '-c', 'until nslookup kafka; do echo waiting for kafka; sleep 4; done;']
       {{- if .Values.config.coreDump.enabled }}
         securityContext:
           runAsUser: 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind enhancement

**What this PR does / why we need it**:
An image pullback occurred in Kafka and MongoDB because, starting August 28th, all existing container images (including older or versioned tags such as `2.50.0`, `10.6`) are being migrated from the public catalog (`docker.io/bitnami`) to the *Bitnami Legacy* repository (`docker.io/bitnamilegacy`). Images in the legacy repository will no longer receive updates, which caused the pullback issue.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #19

**Test Report Added?**:
> /kind TESTED


